### PR TITLE
cli: Add `local-as` attribute in neighbor cmd

### DIFF
--- a/cmd/gobgp/neighbor.go
+++ b/cmd/gobgp/neighbor.go
@@ -1185,6 +1185,7 @@ func modNeighbor(cmdType string, args []string) error {
 	}
 	if cmdType == cmdAdd || cmdType == cmdUpdate {
 		params["as"] = paramSingle
+		params["local-as"] = paramSingle
 		params["family"] = paramSingle
 		params["vrf"] = paramSingle
 		params["route-reflector-client"] = paramSingle
@@ -1193,7 +1194,7 @@ func modNeighbor(cmdType string, args []string) error {
 		params["remove-private-as"] = paramSingle
 		params["replace-peer-as"] = paramFlag
 		params["ebgp-multihop-ttl"] = paramSingle
-		usage += " [ family <address-families-list> | vrf <vrf-name> | route-reflector-client [<cluster-id>] | route-server-client | allow-own-as <num> | remove-private-as (all|replace) | replace-peer-as | ebgp-multihop-ttl <ttl>]"
+		usage += " [ local-as <VALUE> | family <address-families-list> | vrf <vrf-name> | route-reflector-client [<cluster-id>] | route-server-client | allow-own-as <num> | remove-private-as (all|replace) | replace-peer-as | ebgp-multihop-ttl <ttl>]"
 	}
 
 	m, err := extractReserved(args, params)
@@ -1254,6 +1255,13 @@ func modNeighbor(cmdType string, args []string) error {
 				return err
 			}
 			peer.Conf.PeerAsn = uint32(as)
+		}
+		if len(m["local-as"]) > 0 {
+			as, err := strconv.ParseUint(m["local-as"][0], 10, 32)
+			if err != nil {
+				return err
+			}
+			peer.Conf.LocalAsn = uint32(as)
 		}
 		if len(m["family"]) == 1 {
 			peer.AfiSafis = make([]*api.AfiSafi, 0) // for the case of cmdUpdate

--- a/docs/sources/cli-command-syntax.md
+++ b/docs/sources/cli-command-syntax.md
@@ -126,7 +126,7 @@ Also, refer to the following for the detail syntax of each address family.
 
 ```shell
 # add neighbor
-% gobgp neighbor add { <neighbor address> | interface <ifname> } as <as number> [ vrf <vrf-name> | route-reflector-client [<cluster-id>] | route-server-client | allow-own-as <num> | remove-private-as (all|replace) | replace-peer-as | ebgp-multihop-ttl <ttl>]
+% gobgp neighbor add { <neighbor address> | interface <ifname> } as <as number> [ local-as <as number> | vrf <vrf-name> | route-reflector-client [<cluster-id>] | route-server-client | allow-own-as <num> | remove-private-as (all|replace) | replace-peer-as | ebgp-multihop-ttl <ttl>]
 # delete neighbor
 % gobgp neighbor del { <neighbor address> | interface <ifname> }
 % gobgp neighbor <neighbor address> softreset [-a <address family>]


### PR DESCRIPTION
```
➜  gobgp git:(feature/add_local-as_command_in_gobgp_neighbor_cmd) ✗ ./gobgp neighbor add 192.168.1.1 as 555 local-as 111
➜  gobgp git:(feature/add_local-as_command_in_gobgp_neighbor_cmd) ✗ ./gobgp neighbor -j | jq ."[0]"."conf"              
{
  "local_asn": 111,
  "neighbor_address": "192.168.1.1",
  "peer_asn": 555,
  "type": 1
}
➜  gobgp git:(feature/add_local-as_command_in_gobgp_neighbor_cmd) ✗ ./gobgp neighbor update 192.168.1.1 local-as 1994                 
➜  gobgp git:(feature/add_local-as_command_in_gobgp_neighbor_cmd) ✗ ./gobgp neighbor -j | jq ."[0]"."conf"           
{
  "local_asn": 1994,
  "neighbor_address": "192.168.1.1",
  "peer_asn": 555,
  "type": 1
}

```